### PR TITLE
[CWW-5] 서브 도메인 추출 로직 변경

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,9 +33,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   // 현재 호스트에서 subdomain 추출
   const headersList = await headers();
-  const hostname = headersList.get('host')  || headersList.get('authority') || '';
-  console.log('hostname', hostname);
-  
+  const hostname = headersList.get('host') || headersList.get('authority') || '';
+
   let subdomain = '';
   let blog = null;
 
@@ -48,7 +47,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       subdomain = parts[0];
     }
   }
-  console.log('subdomain', subdomain);
   // subdomain이 있으면 블로그 정보 조회
   if (subdomain) {
     try {


### PR DESCRIPTION
-[] 버그 수정

HTTP 요청 헤더에서 host 로 가져오던 서브 도메인 추출 함수를 host 혹은 authority 로 가져오도록 변경